### PR TITLE
Add support for complex queries on the CrossRef works API

### DIFF
--- a/crossrefapi.go
+++ b/crossrefapi.go
@@ -83,9 +83,21 @@ func (c *CrossRefClient) calcDelay() time.Duration {
 	return time.Duration(int64(math.Ceil(float64(c.RateLimitInterval) / float64(c.RateLimitLimit))))
 }
 
+// mergeQueries merges key-value pairs from src into dst, modifying dst in-place,
+// appending values for existing keys.
+// Returns modified dst struct.
+func mergeQueries(dst *url.Values, src url.Values) *url.Values {
+	for k, vs := range src {
+		for _, v := range vs {
+			dst.Add(k, v)
+		}
+	}
+	return dst
+}
+
 // getJSON retrieves the path from the CrossRef API maintaining politeness.
 // It returns a []byte of JSON source or an error
-func (c *CrossRefClient) getJSON(p string) ([]byte, error) {
+func (c *CrossRefClient) getJSON(p string, query *url.Values) ([]byte, error) {
 	var src []byte
 
 	u, err := url.Parse(c.API)
@@ -94,6 +106,12 @@ func (c *CrossRefClient) getJSON(p string) ([]byte, error) {
 	}
 	q := u.Query()
 	q.Set("mailto", c.MailTo)
+
+	// Add additional query parameters, if provided
+	if query != nil {
+		mergeQueries(&q, *query)
+	}
+
 	u.RawQuery = q.Encode()
 	u.Path = p
 
@@ -148,7 +166,7 @@ func (c *CrossRefClient) getJSON(p string) ([]byte, error) {
 
 // TypesJSON return a list of types in JSON source
 func (c *CrossRefClient) TypesJSON() ([]byte, error) {
-	return c.getJSON("types")
+	return c.getJSON("types", nil)
 }
 
 // Types returns the list of supported types as a Object
@@ -171,7 +189,7 @@ func (c *CrossRefClient) WorksJSON(doi string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return c.getJSON(path.Join("works", s))
+	return c.getJSON(path.Join("works", s), nil)
 }
 
 // Works return the Work unmarshaled into a Object (i.e. map[string]interface{})
@@ -183,6 +201,39 @@ func (c *CrossRefClient) Works(doi string) (*Works, error) {
 	if len(src) > 0 {
 		work := &Works{}
 		err = JsonDecode(src, &work)
+		if err != nil {
+			return nil, err
+		}
+		return work, nil
+	}
+	return nil, nil
+}
+
+type WorksQueryResponse WorksResponse[WorksQueryMessage]
+type WorksQueryMessage struct {
+	ItemsPerPage int64 `json:"items-per-page"`
+	Query        struct {
+		StartIndex  int64  `json:"start-index"`
+		SearchTerms string `json:"search-terms"`
+	} `json:"query"`
+	TotalResults int64     `json:"total-results"`
+	NextCursor   string    `json:"next-cursor,omitempty"`
+	Items        []Message `json:"items,omitempty"`
+}
+
+func (c *CrossRefClient) QueryWorks(query WorksQuery) (*WorksQueryResponse, error) {
+	q, err := query.Encode()
+	if err != nil {
+		return nil, err
+	}
+	src, err := c.getJSON("works", &q)
+	if err != nil {
+		return nil, err
+	}
+	if len(src) > 0 {
+		work := &WorksQueryResponse{}
+
+		err = JsonDecode(src, work)
 		if err != nil {
 			return nil, err
 		}

--- a/crossrefapi.go
+++ b/crossrefapi.go
@@ -26,7 +26,7 @@ type CrossRefClient struct {
 	API               string `json:"api"`
 	RateLimitLimit    int    `json:"limit"`
 	RateLimitInterval int    `json:"interval"`
-	LimtCount         int    `json:"limit"`
+	LimitCount        int    `json:"limit_count"`
 	Status            string
 	StatusCode        int
 	LastRequest       time.Time `json:"last_request"`

--- a/crossrefapi_test.go
+++ b/crossrefapi_test.go
@@ -30,7 +30,7 @@ func TestClient(t *testing.T) {
 	}
 
 	// test low level getJSON
-	src, err := api.getJSON("/types")
+	src, err := api.getJSON("/types", nil)
 	if err != nil {
 		t.Error(err)
 		t.FailNow()

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/caltechlibrary/crossrefapi
 
 go 1.22
 
-require github.com/caltechlibrary/doitools v0.0.2
+require (
+	github.com/caltechlibrary/doitools v0.0.2
+	github.com/google/go-querystring v1.1.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
-github.com/caltechlibrary/doitools v0.0.0-20190910184449-c524f84bb2b3 h1:CPVAtgb3KfFDvN/LA6lk3JGT76tVC+PohQWynTkS52s=
-github.com/caltechlibrary/doitools v0.0.0-20190910184449-c524f84bb2b3/go.mod h1:dBtDM+sEd5W27XSuPTcYGUNmkO9PWJ4JMh5bW1EO8L0=
-github.com/caltechlibrary/doitools v0.0.1 h1:c6lvI5l9juo019GGUvuwbzeyv1c6VtSi8mkUv1drgwY=
-github.com/caltechlibrary/doitools v0.0.1/go.mod h1:1K36p/UIkIFM0JVaIVtFStKsFu5xjjYWMWAUExmFnP0=
 github.com/caltechlibrary/doitools v0.0.2 h1:bGFbvEo9scKlYHCAgZCrQO63GwZZDTL7siT0rVTYwmc=
 github.com/caltechlibrary/doitools v0.0.2/go.mod h1:fk83G4/el4EgvWxCwZLAeXvqzL816LdrFCHrkg7Zpp0=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/works.go
+++ b/works.go
@@ -6,6 +6,14 @@ import (
 	"strings"
 )
 
+// WorksResponse is a generic type to represent responsed from the /works endpoint
+type WorksResponse[Message any] struct {
+	Status         string   `json:"status,omitempty"`
+	MessageType    string   `json:"message-type,omitempty"`
+	MessageVersion string   `json:"message-version,omitempty"`
+	Message        *Message `json:"message,omitempty"`
+}
+
 // Works is a representation retrieved the CrossRef REST API using
 // the Works path and a DOI. This is based on documentaiton at
 // https://api.crossref.org/swagger-ui/index.html#/Works/get_works__doi_
@@ -14,12 +22,7 @@ import (
 // NOTE: structure in documentation appears wrong, my test records
 // indicate that some things listed as array of string are really
 // just strings and visa versa.
-type Works struct {
-	Status         string   `json:"status,omitempty"`
-	MessageType    string   `json:"message-type,omitempty"`
-	MessageVersion string   `json:"message-version,omitempty"`
-	Message        *Message `json:"message,omitempty"`
-}
+type Works WorksResponse[Message]
 
 type Message struct {
 	// Institutional information
@@ -70,7 +73,7 @@ type Message struct {
 	Language            string               `json:"language,omitempty"`
 	Link                []*Link              `json:"link,omitempty"`
 	Deposited           *DateObject          `json:"deposited,omitempty"`
-	Score               int                  `json:"score,omitempty"`
+	Score               float32                `json:"score,omitempty"`
 	Degree              string               `json:"degree,omitempty"`
 	SubTitle            []string             `json:"subtitle,omitempty"`
 	Translator          []*Person            `json:"translator,omitempty"`

--- a/works_query.go
+++ b/works_query.go
@@ -1,0 +1,406 @@
+package crossrefapi
+
+import (
+	"encoding"
+	"fmt"
+	"net/url"
+	"reflect"
+	"strings"
+
+	"github.com/google/go-querystring/query"
+)
+
+// WorksQueryFields represents the fields that can be queried in the CrossRef API
+type WorksQueryFields struct {
+	Affiliation          string `url:"query.affiliation,omitempty"`
+	Author               string `url:"query.author,omitempty"`
+	Bibliographic        string `url:"query.bibliographic,omitempty"`
+	Chair                string `url:"query.chair,omitempty"`
+	ContainerTitle       string `url:"query.container-title,omitempty"`
+	Contributor          string `url:"query.contributor,omitempty"`
+	Degree               string `url:"query.degree,omitempty"`
+	Description          string `url:"query.description,omitempty"`
+	Editor               string `url:"query.editor,omitempty"`
+	EventAcronym         string `url:"query.event-acronym,omitempty"`
+	EventLocation        string `url:"query.event-location,omitempty"`
+	EventName            string `url:"query.event-name,omitempty"`
+	EventTheme           string `url:"query.event-theme,omitempty"`
+	FunderName           string `url:"query.funder-name,omitempty"`
+	PublisherLocation    string `url:"query.publisher-location,omitempty"`
+	PublisherName        string `url:"query.publisher-name,omitempty"`
+	StandardsBodyAcronym string `url:"query.standards-body-acronym,omitempty"`
+	StandardsBodyName    string `url:"query.standards-body-name,omitempty"`
+	Title                string `url:"query.title,omitempty"`
+	Translator           string `url:"query.translator,omitempty"`
+}
+
+type SortOrder string
+
+const (
+	Asc  SortOrder = "asc"
+	Desc SortOrder = "desc"
+)
+
+type SortKey string
+
+const (
+	Created             SortKey = "created"
+	Deposited           SortKey = "deposited"
+	Indexed             SortKey = "indexed"
+	IsReferencedByCount SortKey = "is-referenced-by-count"
+	Issued              SortKey = "issued"
+	Published           SortKey = "published"
+	PublishedOnline     SortKey = "published-online"
+	PublishedPrint      SortKey = "published-print"
+	ReferencesCount     SortKey = "references-count"
+	Relevance           SortKey = "relevance"
+	Score               SortKey = "score"
+	LastUpdate          SortKey = "updated" // renamed from `Updated` to avoid name collision
+)
+
+type QuerySortOptions struct {
+	Key   SortKey   `url:"sort,omitempty"`
+	Order SortOrder `url:"order,omitempty"` // default is "desc"
+}
+
+// License represents license-specific filter parameters
+type LicenseFilter struct {
+	URL     string `yaml:"url,omitempty"`
+	Version string `yaml:"version,omitempty"`
+	Delay   *int   `yaml:"delay,omitempty"`
+}
+
+// Relation represents relation-specific filter parameters
+type RelationFilter struct {
+	Type       string `yaml:"type,omitempty"`
+	ObjectType string `yaml:"object-type,omitempty"`
+	Object     string `yaml:"object,omitempty"`
+}
+
+type FullTextFilter struct {
+	Type        string `yaml:"type,omitempty"`
+	Application string `yaml:"application,omitempty"`
+	Version     string `yaml:"version,omitempty"`
+}
+
+type AwardFilter struct {
+	Funder string `yaml:"funder,omitempty"`
+	Number *int   `yaml:"number,omitempty"`
+}
+
+type DateParameter struct {
+	Year  int32
+	Month int32
+	Day   int32
+}
+
+func (d DateParameter) String() string {
+	s := fmt.Sprintf("%d", d.Year)
+	if d.Month <= 0 {
+		return s
+	}
+	s = fmt.Sprintf("%s-%d", s, d.Month)
+	if d.Day <= 0 {
+		return s
+	}
+	s = fmt.Sprintf("%s-%d", s, d.Day)
+	return s
+}
+
+func (d *DateParameter) MarshalText() ([]byte, error) {
+	return []byte(d.String()), nil
+}
+
+// BoolParameter overrides boolean yaml marshalling to comply with CrossRef API spec
+type BoolParameter bool
+
+func (b BoolParameter) MarshalText() ([]byte, error) {
+	if b {
+		return []byte("1"), nil
+	} else {
+		return []byte("0"), nil
+	}
+}
+
+// WorksFilter represents the available filter parameters for the /works endpoint
+type WorksFilter struct {
+	AlternativeID  string `yaml:"alternative-id,omitempty"`
+	Archive        string `yaml:"archive,omitempty"`
+	ArticleNumber  string `yaml:"article-number,omitempty"`
+	Assertion      string `yaml:"assertion,omitempty"`
+	AssertionGroup string `yaml:"assertion-group,omitempty"`
+
+	// Award related fields
+	Award *AwardFilter `yaml:"award,omitempty"`
+
+	CategoryName        string `yaml:"category-name,omitempty"`
+	CitationID          string `yaml:"citation-id,omitempty"`
+	ClinicalTrialNumber string `yaml:"clinical-trial-number,omitempty"`
+	ContainerTitle      string `yaml:"container-title,omitempty"`
+	ContentDomain       string `yaml:"content-domain,omitempty"`
+	DOI                 string `yaml:"doi,omitempty"`
+
+	// From date fields
+	FromAcceptedDate   *DateParameter `yaml:"from-accepted-date,omitempty"`
+	FromApprovedDate   *DateParameter `yaml:"from-approved-date,omitempty"`
+	FromAwardedDate    *DateParameter `yaml:"from-awarded-date,omitempty"`
+	FromCreatedDate    *DateParameter `yaml:"from-created-date,omitempty"`
+	FromDepositDate    *DateParameter `yaml:"from-deposit-date,omitempty"`
+	FromEventEndDate   *DateParameter `yaml:"from-event-end-date,omitempty"`
+	FromEventStartDate *DateParameter `yaml:"from-event-start-date,omitempty"`
+	FromIndexDate      *DateParameter `yaml:"from-index-date,omitempty"`
+	FromIssuedDate     *DateParameter `yaml:"from-issued-date,omitempty"`
+	FromOnlinePubDate  *DateParameter `yaml:"from-online-pub-date,omitempty"`
+	FromPostedDate     *DateParameter `yaml:"from-posted-date,omitempty"`
+	FromPrintPubDate   *DateParameter `yaml:"from-print-pub-date,omitempty"`
+	FromPubDate        *DateParameter `yaml:"from-pub-date,omitempty"`
+	FromUpdateDate     *DateParameter `yaml:"from-update-date,omitempty"`
+
+	// Full text related fields
+	FullText *FullTextFilter `yaml:"full-text,omitempty"`
+
+	// Other fields
+	Funder              string `yaml:"funder,omitempty"`
+	FunderDoiAssertedBy string `yaml:"funder-doi-asserted-by,omitempty"`
+	GroupTitle          string `yaml:"group-title,omitempty"`
+
+	// Boolean flags
+	HasAbstract            *BoolParameter `yaml:"has-abstract"`
+	HasAffiliation         *BoolParameter `yaml:"has-affiliation"`
+	HasArchive             *BoolParameter `yaml:"has-archive"`
+	HasAssertion           *BoolParameter `yaml:"has-assertion"`
+	HasAuthenticatedOrcid  *BoolParameter `yaml:"has-authenticated-orcid"`
+	HasAward               *BoolParameter `yaml:"has-award"`
+	HasClinicalTrialNumber *BoolParameter `yaml:"has-clinical-trial-number"`
+	HasContentDomain       *BoolParameter `yaml:"has-content-domain"`
+	HasDescription         *BoolParameter `yaml:"has-description"`
+	HasDomainRestriction   *BoolParameter `yaml:"has-domain-restriction"`
+	HasEvent               *BoolParameter `yaml:"has-event"`
+	HasFullText            *BoolParameter `yaml:"has-full-text"`
+	HasFunder              *BoolParameter `yaml:"has-funder"`
+	HasFunderDoi           *BoolParameter `yaml:"has-funder-doi"`
+	HasLicense             *BoolParameter `yaml:"has-license"`
+	HasOrcid               *BoolParameter `yaml:"has-orcid"`
+	HasReferences          *BoolParameter `yaml:"has-references"`
+	HasRelation            *BoolParameter `yaml:"has-relation"`
+	HasRorID               *BoolParameter `yaml:"has-ror-id"`
+	HasUpdate              *BoolParameter `yaml:"has-update"`
+	HasUpdatePolicy        *BoolParameter `yaml:"has-update-policy"`
+	IsUpdate               *BoolParameter `yaml:"is-update"`
+
+	// ISBN/ISSN
+	ISBN string `yaml:"isbn,omitempty"`
+	ISSN string `yaml:"issn,omitempty"`
+
+	// License fields
+	License *LicenseFilter `yaml:"license,omitempty"`
+
+	// Award amount
+	GteAwardAmount int `yaml:"gte-award-amount,omitempty"`
+	LteAwardAmount int `yaml:"lte-award-amount,omitempty"`
+
+	// Member and identifiers
+	Member string `yaml:"member,omitempty"`
+	ORCID  string `yaml:"orcid,omitempty"`
+	Prefix string `yaml:"prefix,omitempty"`
+
+	// Relation fields
+	Relation *RelationFilter `yaml:"relation,omitempty"`
+
+	// Type fields
+	RorID    string `yaml:"ror-id,omitempty"`
+	Type     string `yaml:"type,omitempty"`
+	TypeName string `yaml:"type-name,omitempty"`
+
+	// Until date fields
+	UntilAcceptedDate   *DateParameter `yaml:"until-accepted-date,omitempty"`
+	UntilApprovedDate   *DateParameter `yaml:"until-approved-date,omitempty"`
+	UntilAwardedDate    *DateParameter `yaml:"until-awarded-date,omitempty"`
+	UntilCreatedDate    *DateParameter `yaml:"until-created-date,omitempty"`
+	UntilDepositDate    *DateParameter `yaml:"until-deposit-date,omitempty"`
+	UntilEventEndDate   *DateParameter `yaml:"until-event-end-date,omitempty"`
+	UntilEventStartDate *DateParameter `yaml:"until-event-start-date,omitempty"`
+	UntilIndexDate      *DateParameter `yaml:"until-index-date,omitempty"`
+	UntilIssuedDate     *DateParameter `yaml:"until-issued-date,omitempty"`
+	UntilOnlinePubDate  *DateParameter `yaml:"until-online-pub-date,omitempty"`
+	UntilPostedDate     *DateParameter `yaml:"until-posted-date,omitempty"`
+	UntilPrintPubDate   *DateParameter `yaml:"until-print-pub-date,omitempty"`
+	UntilPubDate        *DateParameter `yaml:"until-pub-date,omitempty"`
+	UntilUpdateDate     *DateParameter `yaml:"until-update-date,omitempty"`
+
+	// Update fields
+	UpdateType string `yaml:"update-type,omitempty"`
+	Updates    string `yaml:"updates,omitempty"`
+}
+
+func stringifyValue(v interface{}) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case *string:
+		if t == nil {
+			return ""
+		}
+		return *t
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return fmt.Sprintf("%d", t)
+	case *int, *int8, *int16, *int32, *int64, *uint, *uint8, *uint16, *uint32, *uint64:
+		if t == nil {
+			return ""
+		}
+		return fmt.Sprintf("%d", t)
+	default:
+		return fmt.Sprintf("%v", t)
+	}
+}
+
+func marshalStruct(v interface{}, prefix string) []string {
+	val := reflect.ValueOf(v)
+	typ := val.Type()
+
+	// If it's a pointer, dereference it
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+		typ = val.Type()
+	}
+
+	if val.Kind() != reflect.Struct {
+		return nil
+	}
+
+	var result []string
+
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		fieldVal := val.Field(i)
+
+		// Get the yaml tag
+		tag := field.Tag.Get("yaml")
+		if tag == "" {
+			tag = field.Name
+		}
+		tagParts := strings.Split(tag, ",")
+		name := tagParts[0]
+		omitempty := len(tagParts) > 1 && tagParts[1] == "omitempty"
+
+		if field.Type.Kind() == reflect.Ptr && fieldVal.IsNil() {
+			continue
+		}
+
+		// Skip if field is zero value and omitempty is set
+		if omitempty && (fieldVal.Kind() != reflect.Ptr && fieldVal.IsZero()) {
+			continue
+		}
+
+		// Handle text marshaller interface
+		if marshaller, ok := fieldVal.Interface().(encoding.TextMarshaler); ok && marshaller != nil {
+			text, err := marshaller.MarshalText()
+			if err == nil && len(text) > 0 {
+				key := name
+				if prefix != "" {
+					key = prefix + "." + name
+				}
+				result = append(result, fmt.Sprintf("%s:%s", key, string(text)))
+			}
+			continue
+		}
+
+		// Handle nested structs
+		if fieldVal.Kind() == reflect.Ptr && !fieldVal.IsNil() && fieldVal.Elem().Kind() == reflect.Struct {
+			newPrefix := name
+			if prefix != "" {
+				newPrefix = prefix + "." + name
+			}
+			result = append(result, marshalStruct(fieldVal.Interface(), newPrefix)...)
+			continue
+		}
+		if fieldVal.Kind() == reflect.Struct {
+			newPrefix := name
+			if prefix != "" {
+				newPrefix = prefix + "." + name
+			}
+			result = append(result, marshalStruct(fieldVal.Interface(), newPrefix)...)
+			continue
+		}
+
+		// Handle regular fields
+		if !fieldVal.IsZero() {
+			key := name
+			if prefix != "" {
+				key = prefix + "." + name
+			}
+			result = append(result, fmt.Sprintf("%s:%s", key, stringifyValue(fieldVal.Interface())))
+		}
+	}
+	return result
+}
+
+func (f WorksFilter) MarshalText() ([]byte, error) {
+	parts := marshalStruct(f, "")
+	return []byte(strings.Join(parts, ",")), nil
+}
+
+func (f WorksFilter) Encode() (string, error) {
+	b, err := f.MarshalText()
+	if err != nil {
+		return "", err
+	}
+	// Not very efficient but should not even be noticeable
+	// s := strings.ReplaceAll(string(b), "\n", ",")
+	// s = strings.ReplaceAll(s, ": ", ":")
+	return string(b), nil
+}
+
+type Pagination struct {
+	//The number of items returned in a single response (default is 20, and maximum is 1,000).
+	Rows int64 `url:"rows,omitempty"`
+	// offset parameter can be used to retrieve items starting from a specific index of the result list
+	Offset int64 `url:"offset,omitempty"`
+	// see "Deep-paging" section of CrossRef works API doc
+	Cursor string `url:"cursor,omitempty"`
+}
+
+// WorksQuery represents a query for works in the CrossRef API.
+// See https://api.crossref.org/swagger-ui/index.html#/Works/get_works
+type WorksQuery struct {
+	FreeFormQuery string
+	Fields        *WorksQueryFields
+	Pagination    *Pagination
+	Filters       *WorksFilter
+}
+
+func (q WorksQuery) Encode() (values url.Values, err error) {
+
+	// Named query parameters
+	values, err = query.Values(q.Fields)
+	if err != nil {
+		return values, err
+	}
+
+	// Free form query
+	if strings.TrimSpace(q.FreeFormQuery) != "" {
+		values.Add("query", q.FreeFormQuery)
+	}
+
+	// Pagination
+	if q.Pagination != nil {
+		pag, err := query.Values(q.Pagination)
+		if err != nil {
+			return values, err
+		}
+		mergeQueries(&values, pag)
+	}
+
+	// Filters
+	if q.Filters != nil {
+		filters, err := q.Filters.Encode()
+		if err != nil {
+			return values, err
+		}
+		values.Add("filter", filters)
+	}
+	return values, nil
+}

--- a/works_query_test.go
+++ b/works_query_test.go
@@ -1,0 +1,372 @@
+package crossrefapi
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestWorksFilter_MarshalText(t *testing.T) {
+	tests := []struct {
+		name    string
+		filter  WorksFilter
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Empty filter",
+			filter:  WorksFilter{},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "Single field",
+			filter: WorksFilter{
+				DOI: "10.1234/test",
+			},
+			want:    "doi:10.1234/test",
+			wantErr: false,
+		},
+		{
+			name: "Multiple fields",
+			filter: WorksFilter{
+				DOI:  "10.1234/test",
+				ISSN: "1234-5678",
+				Type: "journal-article",
+			},
+			want:    "doi:10.1234/test,issn:1234-5678,type:journal-article",
+			wantErr: false,
+		},
+		{
+			name: "With date parameter",
+			filter: WorksFilter{
+				FromIssuedDate: &DateParameter{
+					Year:  2020,
+					Month: 6,
+				},
+			},
+			want:    "from-issued-date:2020-6",
+			wantErr: false,
+		},
+		{
+			name: "With bool parameter",
+			filter: WorksFilter{
+				HasAbstract: (*BoolParameter)(boolPtr(true)),
+				HasLicense:  (*BoolParameter)(boolPtr(false)),
+			},
+			want:    "has-abstract:1,has-license:0",
+			wantErr: false,
+		},
+		{
+			name: "With nested filter",
+			filter: WorksFilter{
+				License: &LicenseFilter{
+					URL:     "http://example.com",
+					Version: "1.0",
+				},
+			},
+			want:    "license.url:http://example.com,license.version:1.0",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.filter.MarshalText()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("WorksFilter.MarshalText() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if string(got) != tt.want {
+				t.Errorf("WorksFilter.MarshalText() = %v, want %v", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestWorksQuery_Encode(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   WorksQuery
+		want    url.Values
+		wantErr bool
+	}{
+		{
+			name:    "Empty query",
+			query:   WorksQuery{},
+			want:    url.Values{},
+			wantErr: false,
+		},
+		{
+			name: "Free form query",
+			query: WorksQuery{
+				FreeFormQuery: "test query",
+			},
+			want: url.Values{
+				"query": []string{"test query"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Fields query",
+			query: WorksQuery{
+				Fields: &WorksQueryFields{
+					Author: "John Doe",
+				},
+			},
+			want: url.Values{
+				"query.author": []string{"John Doe"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Pagination query",
+			query: WorksQuery{
+				Pagination: &Pagination{
+					Rows: 10,
+				},
+			},
+			want: url.Values{
+				"rows": []string{"10"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Filters query",
+			query: WorksQuery{
+				Filters: &WorksFilter{
+					DOI: "10.1234/example.doi",
+				},
+			},
+			want: url.Values{
+				"filter": []string{"doi:10.1234/example.doi"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Multiple query parameters and filters",
+			query: WorksQuery{
+				FreeFormQuery: "test query",
+				Fields: &WorksQueryFields{
+					Author: "John Doe",
+				},
+				Pagination: &Pagination{
+					Rows: 10,
+				},
+				Filters: &WorksFilter{
+					DOI:    "10.1234/example.doi",
+					ISSN:   "1234-5678",
+					ORCID:  "0000-0001-2345-6789",
+					Prefix: "10.1234",
+				},
+			},
+			want: url.Values{
+				"query":        []string{"test query"},
+				"query.author": []string{"John Doe"},
+				"rows":         []string{"10"},
+				"filter":       []string{"doi:10.1234/example.doi,issn:1234-5678,orcid:0000-0001-2345-6789,prefix:10.1234"},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.query.Encode()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("WorksQuery.Encode() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !equalValues(got, tt.want) {
+				t.Errorf("WorksQuery.Encode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDateParameter_String(t *testing.T) {
+	tests := []struct {
+		name string
+		date DateParameter
+		want string
+	}{
+		{
+			name: "Year only",
+			date: DateParameter{Year: 2023},
+			want: "2023",
+		},
+		{
+			name: "Year and month",
+			date: DateParameter{Year: 2023, Month: 10},
+			want: "2023-10",
+		},
+		{
+			name: "Full date",
+			date: DateParameter{Year: 2023, Month: 10, Day: 15},
+			want: "2023-10-15",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.date.String(); got != tt.want {
+				t.Errorf("DateParameter.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDateParameter_MarshalText(t *testing.T) {
+	tests := []struct {
+		name    string
+		date    DateParameter
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Year only",
+			date:    DateParameter{Year: 2023},
+			want:    "2023",
+			wantErr: false,
+		},
+		{
+			name:    "Year and month",
+			date:    DateParameter{Year: 2023, Month: 10},
+			want:    "2023-10",
+			wantErr: false,
+		},
+		{
+			name:    "Full date",
+			date:    DateParameter{Year: 2023, Month: 10, Day: 15},
+			want:    "2023-10-15",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.date.MarshalText()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DateParameter.MarshalText() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if string(got) != tt.want {
+				t.Errorf("DateParameter.MarshalText() = %v, want %v", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestBoolParameter_MarshalText(t *testing.T) {
+	tests := []struct {
+		name    string
+		param   BoolParameter
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "True value",
+			param:   BoolParameter(true),
+			want:    "1",
+			wantErr: false,
+		},
+		{
+			name:    "False value",
+			param:   BoolParameter(false),
+			want:    "0",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.param.MarshalText()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("BoolParameter.MarshalText() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if string(got) != tt.want {
+				t.Errorf("BoolParameter.MarshalText() = %v, want %v", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestWorksQuery_RealAPICall(t *testing.T) {
+	client, err := NewCrossRefClient("crossrefapi_test.go", "ls.duchemin@gmail.com")
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+
+	query := WorksQuery{
+		Fields: &WorksQueryFields{
+			Author: "Einstein",
+			Title:  "relativity",
+		},
+		Pagination: &Pagination{
+			Rows: 5,
+		},
+		Filters: &WorksFilter{
+			HasAbstract: (*BoolParameter)(boolPtr(true)),
+			FromIssuedDate: &DateParameter{
+				Year: 1905,
+			},
+			UntilIssuedDate: &DateParameter{
+				Year: 1955,
+			},
+		},
+	}
+
+	works, err := client.QueryWorks(query)
+	if err != nil || works == nil {
+		t.Fatalf("WorksQuery real API call failed: %v", err)
+	}
+
+	if len(works.Message.Items) == 0 {
+		t.Error("Expected to get some works but got none")
+	}
+
+	if len(works.Message.Items) > 5 {
+		t.Errorf("Expected max 5 results but got %d", len(works.Message.Items))
+	}
+
+	// Verify at least one work matches our criteria
+	found := false
+	for _, work := range works.Message.Items {
+		for _, author := range work.Author {
+			if strings.Contains(strings.ToLower(author.Given)+" "+strings.ToLower(author.Family), "einstein") {
+				found = true
+				break
+			}
+		}
+		if found {
+			break
+		}
+	}
+
+	if !found {
+		t.Error("Expected to find at least one work by Einstein")
+	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func equalValues(a, b url.Values) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if len(v) != len(b[k]) {
+			return false
+		}
+		for i, vv := range v {
+			if vv != b[k][i] {
+				return false
+			}
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Hi ! Thank you for making this tool available to the community. I'm already using it for working with DOIs and it does a good job at it. 

I also needed the querying features exposed in the CrossRef works API (https://api.crossref.org/swagger-ui/index.html#/Works/get_works), so I came up with this PR which implements most of its capabilities, with the exception of **facets** because this part of the API is poorly documented (or maybe I'm just dumb).

This PR does not introduce any breaking changes, and only extends the API of the package. Existing and new type names could be improved though (e.g. `Message`), but that's a decision that I think would be better left to the package maintainer(s).

Cheers